### PR TITLE
update: go get not need https://

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -68,7 +68,7 @@ pip install pyfury
 ### Golang
 
 ```bash
-go get https://github.com/apache/incubator-fury/go/fury
+go get github.com/apache/incubator-fury/go/fury
 ```
 
 ### JavaScript


### PR DESCRIPTION
$ go get https://github.com/apache/incubator-fury/go/fury
go: malformed module path "https:/github.com/apache/incubator-fury/go/fury": invalid char ':'