### PR TITLE
Fix the problem that github star does not display.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -44,7 +44,9 @@ const config: Config = {
   ],
   plugins: [require.resolve('docusaurus-lunr-search')],
   themeConfig: {
-    // Replace with your project's social card
+    metadata: [
+      {'http-equiv': 'Content-Security-Policy', content: "frame-src 'self' https://ghbtns.com"},
+    ],
     navbar: {
       title: '',
       logo: {


### PR DESCRIPTION
The current fury website github star displays abnormally.

![image](https://github.com/apache/incubator-fury-site/assets/116876207/91e18c62-8f63-45e0-9360-1c5c7636283c)

The exception information is as follows:

`Refused to frame 'https://ghbtns.com/' because it violates the following Content Security Policy directive: "frame-src 'self'".`