### PR TITLE
remove snapshot maven install

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -5,36 +5,7 @@ sidebar_position: 0
 ---
 
 ### Java
-
-Nightly snapshot:
-
-```xml
-<repositories>
-  <repository>
-    <id>apache</id>
-    <url>https://repository.apache.org/snapshots/</url>
-    <releases>
-      <enabled>false</enabled>
-    </releases>
-    <snapshots>
-      <enabled>true</enabled>
-    </snapshots>
-  </repository>
-</repositories>
-<dependency>
-  <groupId>org.apache.fury</groupId>
-  <artifactId>fury-core</artifactId>
-  <version>0.5.0-SNAPSHOT</version>
-</dependency>
-<!-- row/arrow format support -->
-<!-- <dependency>
-  <groupId>org.apache.fury</groupId>
-  <artifactId>fury-format</artifactId>
-  <version>0.5.0-SNAPSHOT</version>
-</dependency> -->
-```
-
-Release version:
+To add a dependency on Fury using Maven, use the following:
 
 ```xml
 <dependency>
@@ -59,9 +30,6 @@ libraryDependencies += "org.furyio" % "fury-core" % "0.4.1"
 ### Python
 
 ```bash
-# Python wheel will be released in the future.
-# Currently you need to specify `--pre` to install
-# the unstable version.
 pip install pyfury
 ```
 
@@ -85,5 +53,4 @@ npm install @furyjs/fury
 [dependencies]
 fury = { git= "https://github.com/apache/incubator-fury.git", branch = "main" }
 lazy_static = { version = "1.4.0" }
-
 ```

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -27,12 +27,6 @@ Maven groupId will be changed to `org.apache.fury` when next version is released
 libraryDependencies += "org.furyio" % "fury-core" % "0.4.1"
 ```
 
-### Python
-
-```bash
-pip install pyfury
-```
-
 ### Golang
 
 ```bash


### PR DESCRIPTION
This PR removes snapshot maven artifact from install page.

As incubator [vote thead](https://lists.apache.org/thread/og2f34rqgw472og9371ns90jq9tqx9qz) said, snapshot packages should not be included in project website  and it's not allowed except for developers according apache release policy: https://www.apache.org/legal/release-policy.html#what .

![image](https://github.com/apache/incubator-fury-site/assets/12445254/ed7a6a38-0182-429b-ba7a-56d36299f007)


 