### PR TITLE
fix install and download pages

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -33,7 +33,6 @@ sha512sum --check apache-fury-incubating-0.5.0-src.tar.gz
 It should output something like:
 
 ```bash
-apache-fury-incubating-0.5.0-src.tar.gz
 apache-fury-incubating-0.5.0-src.tar.gz: OK
 ```
 
@@ -50,7 +49,7 @@ gpg --import KEYS
 
 Then you can verify signature:
 ```bash
-gpg --verify apache-fury-incubating-0.5.0-src.tar.gz.asc
+gpg --verify apache-fury-incubating-0.5.0-src.tar.gz.asc apache-fury-incubating-0.5.0-src.tar.gz
 ```
 
 If something like the following appears, it means the signature is correct:

--- a/docs/download.md
+++ b/docs/download.md
@@ -11,11 +11,69 @@ For binary install, please see Fury [install](/docs/start/install/) document.
 
 Apache Fury (Incubating) hasn't made a release since joining the Apache Incubator.
 
-## Verify a release
-
-Please verify the release with corresponding hashes(sha512), signatures and [release KEYS](https://downloads.apache.org/incubator/fury/KEYS).
-
-
 ## All archived releases
 
 Apache Fury (Incubating) hasn't made a release since joining the Apache Incubator.
+
+## Verify a release
+
+It's highly recommended to verify the files that you download.
+
+Fury provides SHA digest and PGP signature files for all the files that we host on the download site. 
+These files are named after the files they relate to but have `.sha512/.asc` extensions.
+
+### Verifying Checksums
+
+To verify the SHA digests, you need the .tgz and its associated .tgz.sha512 file. An example command:
+
+```bash
+for i in *.tar.gz; do echo $i; sha512sum --check  $i.sha512; done
+```
+
+It should output something like:
+
+```bash
+apache-fury-incubating-0.5.0-src.tar.gz
+apache-fury-incubating-0.5.0-src.tar.gz: OK
+```
+
+### Verifying Signatures
+
+To verify the PGP signatures, you will need to download and import the 
+[release KEYS](https://downloads.apache.org/incubator/fury/KEYS):
+
+```bash
+curl https://downloads.apache.org/incubator/fury/KEYS >KEYS # Download KEYS
+gpg --import KEYS # Import KEYS to local
+# Then, trust the public key
+```
+
+Then you can verify signature:
+```bash
+for i in *.tar.gz; do echo $i; gpg --verify $i.asc $i; done
+```
+
+If something like the following appears, it means the signature is correct:
+
+```bash
+apache-fury-incubating-0.5.0-src.tar.gz
+gpg: Signature made Wed 17 Apr 2024 11:49:45 PM CST using RSA key ID 5E580BA4
+gpg: checking the trustdb
+gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model
+gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
+gpg: Good signature from "chaokunyang (CODE SIGNING KEY) <chaokunyang@apache.org>"
+```
+
+You should also verify the key using a command like:
+
+```bash
+gpg --fingerprint 1E2CDAE4C08AD7D694D1CB139D7BE8E45E580BA4
+```
+
+It should output something like:
+```bash
+pub   rsa4096 2024-03-27 [SC]
+      1E2C DAE4 C08A D7D6 94D1  CB13 9D7B E8E4 5E58 0BA4
+uid           [ unknown] chaokunyang (CODE SIGNING KEY) <chaokunyang@apache.org>
+sub   rsa4096 2024-03-27 [E]
+```

--- a/docs/download.md
+++ b/docs/download.md
@@ -5,7 +5,7 @@ title: Apache Fury(incubating) Download
 
 The official Apache Fury releases are provided as source artifacts.
 
-For binary install, please see Fury [install](https://fury.apache.org/docs/start/install/) document.
+For binary install, please see Fury [install](/docs/start/install/) document.
 
 ## The latest release 
 
@@ -19,5 +19,3 @@ Please verify the release with corresponding hashes(sha512), signatures and [rel
 ## All archived releases
 
 Apache Fury hasn't make a release since joined Apache Incubator.
-
-

--- a/docs/download.md
+++ b/docs/download.md
@@ -39,8 +39,10 @@ apache-fury-incubating-0.5.0-src.tar.gz: OK
 
 ### Verifying Signatures
 
-To verify the PGP signatures, you will need to download and import the 
-[release KEYS](https://downloads.apache.org/incubator/fury/KEYS):
+To verify the PGP signatures, you will need to download the 
+[release KEYS](https://downloads.apache.org/incubator/fury/KEYS) first.
+
+Then import the downloaded `KEYS`:
 
 ```bash
 gpg --import KEYS

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,0 +1,14 @@
+---
+id: download
+title: Apache Fury(incubating) Download
+---
+
+## The latest release 
+Apache Fury hasn't make a release since joined Apache Incubator.
+
+
+## All archived releases
+
+Apache Fury hasn't make a release since joined Apache Incubator.
+
+

--- a/docs/download.md
+++ b/docs/download.md
@@ -9,7 +9,7 @@ For binary install, please see Fury [install](/docs/start/install/) document.
 
 ## The latest release 
 
-Apache Fury hasn't make a release since joined Apache Incubator.
+Apache Fury (Incubating) hasn't made a release since joining the Apache Incubator.
 
 ## Verify a release
 
@@ -18,4 +18,4 @@ Please verify the release with corresponding hashes(sha512), signatures and [rel
 
 ## All archived releases
 
-Apache Fury hasn't make a release since joined Apache Incubator.
+Apache Fury (Incubating) hasn't made a release since joining the Apache Incubator.

--- a/docs/download.md
+++ b/docs/download.md
@@ -43,9 +43,7 @@ To verify the PGP signatures, you will need to download and import the
 [release KEYS](https://downloads.apache.org/incubator/fury/KEYS):
 
 ```bash
-curl https://downloads.apache.org/incubator/fury/KEYS >KEYS # Download KEYS
-gpg --import KEYS # Import KEYS to local
-# Then, trust the public key
+gpg --import KEYS
 ```
 
 Then you can verify signature:

--- a/docs/download.md
+++ b/docs/download.md
@@ -5,6 +5,8 @@ title: Apache Fury(incubating) Download
 
 The official Apache Fury releases are provided as source artifacts.
 
+For binary install, please see Fury [install](https://fury.apache.org/docs/start/install/) document.
+
 ## The latest release 
 
 Apache Fury hasn't make a release since joined Apache Incubator.

--- a/docs/download.md
+++ b/docs/download.md
@@ -24,7 +24,7 @@ These files are named after the files they relate to but have `.sha512/.asc` ext
 
 ### Verifying Checksums
 
-To verify the SHA digests, you need the .tgz and its associated .tgz.sha512 file. An example command:
+To verify the SHA digests, you need the `.tgz` and its associated `.tgz.sha512` file. An example command:
 
 ```bash
 sha512sum --check apache-fury-incubating-0.5.0-src.tar.gz

--- a/docs/download.md
+++ b/docs/download.md
@@ -27,7 +27,7 @@ These files are named after the files they relate to but have `.sha512/.asc` ext
 To verify the SHA digests, you need the .tgz and its associated .tgz.sha512 file. An example command:
 
 ```bash
-for i in *.tar.gz; do echo $i; sha512sum --check  $i.sha512; done
+sha512sum --check apache-fury-incubating-0.5.0-src.tar.gz
 ```
 
 It should output something like:
@@ -50,13 +50,12 @@ gpg --import KEYS # Import KEYS to local
 
 Then you can verify signature:
 ```bash
-for i in *.tar.gz; do echo $i; gpg --verify $i.asc $i; done
+gpg --verify apache-fury-incubating-0.5.0-src.tar.gz.asc
 ```
 
 If something like the following appears, it means the signature is correct:
 
 ```bash
-apache-fury-incubating-0.5.0-src.tar.gz
 gpg: Signature made Wed 17 Apr 2024 11:49:45 PM CST using RSA key ID 5E580BA4
 gpg: checking the trustdb
 gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model

--- a/docs/download.md
+++ b/docs/download.md
@@ -3,8 +3,15 @@ id: download
 title: Apache Fury(incubating) Download
 ---
 
+The official Apache Fury releases are provided as source artifacts.
+
 ## The latest release 
+
 Apache Fury hasn't make a release since joined Apache Incubator.
+
+## Verify a release
+
+Please verify the release with corresponding hashes(sha512), signatures and [release KEYS](https://downloads.apache.org/incubator/fury/KEYS).
 
 
 ## All archived releases

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -22,29 +22,6 @@ To add a dependency on Fury using Maven, use the following:
 ```
 Maven groupId will be changed to `org.apache.fury` when next version is released.
 
-### Scala
-```sbt
-libraryDependencies += "org.furyio" % "fury-core" % "0.4.1"
-```
-
-### Golang
-
-```bash
-go get github.com/apache/incubator-fury/go/fury
-```
-
-### JavaScript
-
-```bash
-npm install @furyjs/fury
-```
-
-### Rust
-
-```bash
-# Cargo.toml
-
-[dependencies]
-fury = { git= "https://github.com/apache/incubator-fury.git", branch = "main" }
-lazy_static = { version = "1.4.0" }
-```
+Note:
+> This is released before Fury joined Apache Incubator, Fury haven't make a release under ASF yet.
+> The maven groupId will be replaced to `org.apache.fury` when next version is released.

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -4,6 +4,11 @@ title: Install
 sidebar_position: 0
 ---
 
+The official Apache Fury releases are provided as source artifacts.
+
+For source download, please see Fury [download](https://fury.apache.org/docs/download/) page.
+
+
 ### Java
 To add a dependency on Fury using Maven, use the following:
 

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -25,8 +25,8 @@ To add a dependency on Fury using Maven, use the following:
   <version>0.4.1</version>
 </dependency> -->
 ```
-Maven groupId will be changed to `org.apache.fury` when next version is released.
+Maven groupId will be changed to `org.apache.fury` when the next version is released.
 
 Note:
-> This is released before Fury joined Apache Incubator, Fury haven't make a release under ASF yet.
-> The maven groupId will be replaced to `org.apache.fury` when next version is released.
+> This was released before Fury joined the Apache Incubator, Fury hasn't made a release under ASF yet.
+> The maven groupId will be replaced to `org.apache.fury` when the next version is released.

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -6,7 +6,7 @@ sidebar_position: 0
 
 The official Apache Fury releases are provided as source artifacts.
 
-For source download, please see Fury [download](https://fury.apache.org/docs/download/) page.
+For source download, please see Fury [download](/docs/download/) page.
 
 
 ### Java

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -84,6 +84,13 @@ const config: Config = {
           position: 'right',
           label: 'Specification',
         },
+        {
+          type: 'doc',
+          docId: 'download',
+          position: 'right',
+          to: 'docs/download',
+          label: 'Download',
+        },
         {to: '/blog', label: 'Blog', position: 'right'},
         {
           type: 'dropdown',


### PR DESCRIPTION
This PR fix  install  pages by add non-asf notes adn remove install for language that we don't publish in next release:
![image](https://github.com/apache/incubator-fury-site/assets/12445254/a79c2f25-9320-442f-86cf-e4dd3ca1b5f5)
And add a download pages, which just say: `Apache Fury hasn't make a release since joined Apache Incubator`:
![image](https://github.com/apache/incubator-fury-site/assets/12445254/4f8ad2d3-9267-41b7-af4c-201f7ad19e97)